### PR TITLE
Use unicode literals in template tags

### DIFF
--- a/disqus/templatetags/disqus_tags.py
+++ b/disqus/templatetags/disqus_tags.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import base64
 import hashlib
 import hmac


### PR DESCRIPTION
There are (ascii) format string literals like this one on line 58:

```
js = '\tvar {} = "{}";'
```

These get substituted with values from the page.  e.g. for
discus_title yor get a version of the page title which may be unicode
and might contain non ascii characters which triggers a decoding error.
